### PR TITLE
Pk edit this page 20240417

### DIFF
--- a/mwb.py
+++ b/mwb.py
@@ -131,6 +131,9 @@ def main():
     config = load_config(args.config)
     if not 'recent_changes_count' in config:
         config['recent_changes_count'] = 5
+    # old 'repo' is now 'repo_html'; copy value over for old wikis
+    if not 'repo_html' in config:
+        config['repo_html'] = config['repo']
 
     # remember paths
     dir_output = Path(args.output).resolve().as_posix()
@@ -241,7 +244,9 @@ def main():
                     build_time=build_time,
                     wiki_title=config['wiki_title'],
                     author=config['author'],
-                    repo=config['repo'],
+                    repo=config['repo_html'],
+                    repo_html=config['repo_html'],
+                    repo_uri=config['repo_uri'],
                     license=config['license'],
                     title=Path(file).stem,
                     markdown_body=markdown_body,
@@ -305,7 +310,9 @@ def main():
             build_time=build_time,
             wiki_title=config['wiki_title'],
             author=config['author'],
-            repo=config['repo'],
+            repo=config['repo_html'],
+            repo_html=config['repo_html'],
+            repo_uri=config['repo_uri'],
             license=config['license'],
             sidebar_body=sidebar_body,
             lunr_index_sitepath=lunr_index_sitepath,
@@ -339,7 +346,9 @@ def main():
             pages_chrono=all_pages_chrono,
             wiki_title=config['wiki_title'],
             author=config['author'],
-            repo=config['repo'],
+            repo=config['repo_html'],
+            repo_html=config['repo_html'],
+            repo_uri=config['repo_uri'],
             license=config['license'],
             lunr_index_sitepath=lunr_index_sitepath,
             lunr_posts_sitepath=lunr_posts_sitepath,
@@ -354,7 +363,9 @@ def main():
             pages=recent_pages,
             wiki_title=config['wiki_title'],
             author=config['author'],
-            repo=config['repo'],
+            repo=config['repo_html'],
+            repo_html=config['repo_html'],
+            repo_uri=config['repo_uri'],
             license=config['license'],
             sidebar_body=sidebar_body,
             lunr_index_sitepath=lunr_index_sitepath,

--- a/mwb.py
+++ b/mwb.py
@@ -28,6 +28,7 @@ import sys
 import textwrap
 import time
 import traceback
+from urllib.parse import quote
 
 # pip install
 from dateutil.parser import parse # pip install python-dateutil
@@ -131,9 +132,6 @@ def main():
     config = load_config(args.config)
     if not 'recent_changes_count' in config:
         config['recent_changes_count'] = 5
-    # old 'repo' is now 'repo_html'; copy value over for old wikis
-    if not 'repo_html' in config:
-        config['repo_html'] = config['repo']
 
     # remember paths
     dir_output = Path(args.output).resolve().as_posix()
@@ -240,13 +238,16 @@ def main():
                 # render and output HTML
                 file_id = hashlib.md5(Path(file).stem.lower().encode()).hexdigest()
                 markdown_body = markdown_convert(markdown_text, args.wiki, file_id)
+                if 'edit_url' in config and 'edit_branch' in config:
+                    edit_url = (f"{config['edit_url']}edit/{config['edit_branch']}/{quote(Path(file).relative_to(dir_wiki).as_posix())}")
+                else:
+                    edit_url = ''
                 html = page.render(
                     build_time=build_time,
                     wiki_title=config['wiki_title'],
                     author=config['author'],
-                    repo=config['repo_html'],
-                    repo_html=config['repo_html'],
-                    repo_uri=config['repo_uri'],
+                    repo=config['repo'],
+                    edit_url=edit_url,
                     license=config['license'],
                     title=Path(file).stem,
                     markdown_body=markdown_body,
@@ -310,9 +311,7 @@ def main():
             build_time=build_time,
             wiki_title=config['wiki_title'],
             author=config['author'],
-            repo=config['repo_html'],
-            repo_html=config['repo_html'],
-            repo_uri=config['repo_uri'],
+            repo=config['repo'],
             license=config['license'],
             sidebar_body=sidebar_body,
             lunr_index_sitepath=lunr_index_sitepath,
@@ -346,9 +345,7 @@ def main():
             pages_chrono=all_pages_chrono,
             wiki_title=config['wiki_title'],
             author=config['author'],
-            repo=config['repo_html'],
-            repo_html=config['repo_html'],
-            repo_uri=config['repo_uri'],
+            repo=config['repo'],
             license=config['license'],
             lunr_index_sitepath=lunr_index_sitepath,
             lunr_posts_sitepath=lunr_posts_sitepath,
@@ -363,9 +360,7 @@ def main():
             pages=recent_pages,
             wiki_title=config['wiki_title'],
             author=config['author'],
-            repo=config['repo_html'],
-            repo_html=config['repo_html'],
-            repo_uri=config['repo_uri'],
+            repo=config['repo'],
             license=config['license'],
             sidebar_body=sidebar_body,
             lunr_index_sitepath=lunr_index_sitepath,

--- a/mwb.py
+++ b/mwb.py
@@ -7,7 +7,7 @@
 #
 ################################################################
 
-APPVERSION = 'v3.2.0'
+APPVERSION = 'v3.2.1-candidate'
 APPNAME = 'Massive Wiki Builder'
 
 # set up logging
@@ -347,6 +347,7 @@ def main():
             author=config['author'],
             repo=config['repo'],
             license=config['license'],
+            sidebar_body=sidebar_body,
             lunr_index_sitepath=lunr_index_sitepath,
             lunr_posts_sitepath=lunr_posts_sitepath,
         )


### PR DESCRIPTION
Add code to support "edit_url" and "edit_branch" in mwb.yaml.

A URL is then constructed with the edit_url, edit_branch, and current page filename URL-encoded is then passed to the theme.

Assumption: the edit URL on the forge is constructed the way GitHub constructs edit URLs. Perhaps we should take "edit_url" as something preconstructed with the repo root and the "edit" command in the URL.